### PR TITLE
Check type of value returned from sabotage

### DIFF
--- a/game.py
+++ b/game.py
@@ -156,6 +156,7 @@ class Game:
             result = False
             if p.spy:
                 result = p.sabotage()
+                assert type(result) is bool, "Please return a boolean from sabotage()."
             sabotaged += int(result)
 
         if sabotaged == 0:


### PR DESCRIPTION
Similar to the check in place for voting, adding this check to the
sabotage call prevents bots from playing multiple sabotage cards or
a negative amount of sabotage cards.

An example of a cheating bot:

```
from player import Bot
import random

class CheatingHippie(Bot):
    def select(self, players, count):
        return [self] + random.sample(self.others(), count - 1)

    def vote(self, team):
        return True

    def sabotage(self):
        # Frames team members!
        return 2
```
